### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -400,7 +400,7 @@ def upload_file():
             return jsonify({'task_id': task_id})
         except Exception as e:
             logger.error(f"Exception during file upload: {e}")
-            return jsonify({'error': f'Upload failed: {str(e)}'}), 500
+            return jsonify({'error': 'An internal error occurred.'}), 500
 
 @app.route('/status/<task_id>')
 def check_status(task_id):


### PR DESCRIPTION
Potential fix for [https://github.com/RAHB-REALTORS-Association/wav-maker/security/code-scanning/4](https://github.com/RAHB-REALTORS-Association/wav-maker/security/code-scanning/4)

To fix the issue, we will replace the detailed error message sent to the user with a generic error message, such as "An internal error occurred." The detailed exception information will still be logged on the server using `logger.error`. This ensures that developers can debug the issue without exposing sensitive information to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
