### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -57,6 +59,9 @@ jobs:
     name: Build and Publish Docker Image
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     
     # Skip this job for PRs from forks since they don't have access to secrets
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -101,6 +106,8 @@ jobs:
     name: Notify Release
     needs: build-and-publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/v')
     
     steps:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -107,7 +107,9 @@ jobs:
     needs: build-and-publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents:
+        read: true
+        write: true
     if: startsWith(github.ref, 'refs/tags/v')
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/RAHB-REALTORS-Association/wav-maker/security/code-scanning/1](https://github.com/RAHB-REALTORS-Association/wav-maker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow and its jobs. The permissions will be tailored to the specific needs of each job:

1. **`test` job:** This job only needs to read the repository contents to run tests and linting. We will set `contents: read`.
2. **`build-and-publish` job:** This job requires additional permissions to log in to the GitHub Container Registry and push Docker images. We will set `contents: read` and `packages: write`.
3. **`notify` job:** This job requires permissions to create a release and access repository contents. We will set `contents: read` and `contents: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
